### PR TITLE
Add bidirectional reschedule approval flow for bookings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,14 @@
       "Bash(npm run build:*)",
       "Bash(dotnet ef migrations add:*)",
       "Bash(dotnet ef database update:*)",
-      "Bash(npx vite build)"
+      "Bash(npx vite build)",
+      "Read(//c/Users/adam_/source/repos/Kursserver/Kursserver/Models/**)",
+      "Bash(git checkout:*)",
+      "Read(//c/Users/adam_/source/repos/Kursserver/Kursserver/**)",
+      "Read(//c/Users/adam_/.claude/**)",
+      "Bash(git -C \"c:/Users/adam_/source/repos/React/kurshemsida\" branch --show-current)",
+      "Bash(git -C \"c:/Users/adam_/source/repos/React/kurshemsida\" log --oneline origin/main..HEAD)",
+      "Bash(git -C \"c:/Users/adam_/source/repos/React/kurshemsida\" diff origin/main...HEAD --stat)"
     ],
     "additionalDirectories": [
       "C:\\Users\\adam_\\source\\repos\\Kursserver\\Kursserver\\Dto",

--- a/src/api/BookingService.ts
+++ b/src/api/BookingService.ts
@@ -24,11 +24,19 @@ export interface Booking {
   status: string;
   reason?: string;
   seen?: boolean;
+  rescheduledBy?: string;
 }
 
 // Get free (available) time slots for coaches to book
 export async function getAvailabilities(): Promise<Availability[]> {
   const res = await fetch(`${API_URL}/free`, { credentials: 'include' });
+  return res.json();
+}
+
+// Get a single availability by id — accessible by coaches too
+export async function getAvailabilityById(id: number): Promise<Availability> {
+  const res = await fetch(`${API_URL}/${id}`, { credentials: 'include' });
+  if (!res.ok) throw new Error(`Failed to fetch availability (${res.status})`);
   return res.json();
 }
 
@@ -129,13 +137,13 @@ export async function cancelBooking(id: number, reason?: string): Promise<Bookin
   return res.json();
 }
 
-// Reschedule a booking — for coach (own) or admin/teacher; resets status to pending
-export async function rescheduleBooking(id: number, startTime: string, endTime: string, reason?: string): Promise<Booking> {
+// Reschedule a booking — for coach (own) or admin/teacher; sets status to rescheduled
+export async function rescheduleBooking(id: number, startTime: string, endTime: string, reason?: string, rescheduledBy?: string): Promise<Booking> {
   const res = await fetch(`${API_URL}/bookings/${id}/reschedule`, {
     method: 'PUT',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ id, startTime, endTime, reason: reason ?? '' })
+    body: JSON.stringify({ id, startTime, endTime, reason: reason ?? '', rescheduledBy: rescheduledBy ?? '' })
   });
   if (!res.ok) {
     const text = await res.text();


### PR DESCRIPTION
## Summary
- Added `rescheduled` booking status and `RescheduledBy` field to track who initiated the reschedule
- Admin can now suggest a new time on pending bookings (Neka / Föreslå annan tid / Godkänn)
- Coach can respond to admin-rescheduled bookings with approve, suggest another time, or decline
- Coach can also suggest a new time on initial pending booking requests instead of having to approve first
- Fixed auth claim bug in reschedule endpoint (was using NameIdentifier/email instead of user ID)