### PR TITLE
feat: add Kodsidor page and remove Alexandra filters

### DIFF
--- a/.claude/PROJECT_CONTEXT.md
+++ b/.claude/PROJECT_CONTEXT.md
@@ -88,11 +88,12 @@ Projekt.tsx → useAddProject() → projectService.addProject(dto) → POST /api
 - `CodeEditor` — Monaco wrapper for exercise/project code
 
 ## Routing (App.tsx)
-Auth-based conditional rendering: not logged in → Login, guest → Homepage only, logged in → full app with AppLayout.
+Auth-based conditional rendering: not logged in → Login (except public routes like `/kodsidor`), guest → Homepage + public routes, logged in → full app with AppLayout.
 
 | Path | Component | Guard |
 |------|-----------|-------|
 | `/` | Index | — |
+| `/kodsidor` | Kodsidor | — (public, accessible without login) |
 | `/login` | Login | Redirects if logged in |
 | `/projekt` | Projekt | — |
 | `/ovningar` | Ovningar | — |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import Deltagare from './pages/Deltagare';
 import StudentSchedule from './pages/StudentSchedule';
 import Klassrum from './pages/Klassrum';
 import MeddelandenPage from './pages/MeddelandenPage';
+import Kodsidor from './pages/Kodsidor';
 import ProtectedRoute from './components/ProtectedRoute';
 
 const queryClient = new QueryClient();
@@ -47,17 +48,18 @@ function AppRoutes() {
     );
   }
 
-  // Not logged in and not guest → show login
+  // Not logged in and not guest → show login (but allow public pages)
   if (!isLoggedIn && !isGuest) {
     return (
       <Routes>
         <Route path="/login" element={<Login />} />
+        <Route path="/kodsidor" element={<AppLayout><Kodsidor /></AppLayout>} />
         <Route path="*" element={<Navigate to="/login" replace />} />
       </Routes>
     );
   }
 
-  // Guest → only homepage
+  // Guest → homepage and public pages
   if (isGuest && !isLoggedIn) {
     return (
       <Routes>
@@ -69,6 +71,7 @@ function AppRoutes() {
             </AppLayout>
           }
         />
+        <Route path="/kodsidor" element={<AppLayout><Kodsidor /></AppLayout>} />
         <Route path="/login" element={<Login />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
@@ -80,6 +83,7 @@ function AppRoutes() {
     <AppLayout>
       <Routes>
         <Route path="/" element={<Index />} />
+        <Route path="/kodsidor" element={<Kodsidor />} />
         {/* Student routes — temporarily disabled (students cannot log in) */}
         {/* <Route path="/projekt" element={<Projekt />} /> */}
         {/* <Route path="/ovningar" element={<Ovningar />} /> */}

--- a/src/changelogs/2026-04-10-feat-kodsidor-page.json
+++ b/src/changelogs/2026-04-10-feat-kodsidor-page.json
@@ -1,0 +1,15 @@
+{
+  "displaydate": null,
+  "entries": {
+    "admin": [
+      "Ny publik sida \"Kodsidor\" (/kodsidor) med 19 lärplattformar och kodspel, uppdelat i fyra flikar: Rekommenderade, Kompletterande, Kodutmaningar och Minispel.",
+      "Knappen \"Utforska kodsidor\" tillagd i hero-sektionen på startsidan.",
+      "Alexandra-filtret borttaget — hon visas nu i schemaläggning, kontaktlistor och bokningsöverföringar."
+    ],
+    "coach": [
+      "Alexandra visas nu i kontaktlistan och bokningsvyn.",
+      "Ny sida \"Kodsidor\" tillgänglig från startsidan — där du kan visa intresserade deltagare vilka sidor vi använder"
+    ],
+    "student": []
+  }
+}

--- a/src/components/admin/AdminSchedule.tsx
+++ b/src/components/admin/AdminSchedule.tsx
@@ -110,7 +110,7 @@ function AdminSchedule() {
   const coaches = useMemo(() => allUsers.filter((u) => u.authLevel === 3 && u.isActive), [allUsers]);
   const students = useMemo(() => allUsers.filter((u) => u.authLevel === 4 && u.isActive), [allUsers]);
   const adminColorMap = useMemo(() => getAdminColorMap(allAdmins), [allAdmins]);
-  const otherTeachers = useMemo(() => allAdmins.filter((a) => a.firstName !== 'Alexandra'), [allAdmins]);
+  const otherTeachers = useMemo(() => allAdmins, [allAdmins]);
   const nameMap = useMemo(() => {
     const map = new Map<number, string>();
     allUsers.forEach((u) => map.set(u.id, `${u.firstName} ${u.lastName}`));

--- a/src/components/admin/CoachAttendance.tsx
+++ b/src/components/admin/CoachAttendance.tsx
@@ -457,7 +457,7 @@ const CoachAttendance: React.FC<CoachAttendanceProps> = ({ seluser = null, showC
                     <Table>
                       <TableHeader><TableRow><TableHead>Namn</TableHead><TableHead>Telefonnummer</TableHead><TableHead>Email</TableHead></TableRow></TableHeader>
                       <TableBody>
-                        {users?.filter((u) => u.authLevel <= 2 && u.isActive && u.firstName !== "Alexandra").map((contact) => (
+                        {users?.filter((u) => u.authLevel <= 2 && u.isActive).map((contact) => (
                           <TableRow key={contact.id}>
                             <TableCell className={contact.id === selectedUser?.contactId ? "bg-green-100" : ""}>{contact.firstName} {contact.lastName}</TableCell>
                             <TableCell className={contact.id === selectedUser?.contactId ? "bg-green-100" : ""}>{contact.telephone}</TableCell>

--- a/src/components/calendar/BookingDetailsDialog.tsx
+++ b/src/components/calendar/BookingDetailsDialog.tsx
@@ -75,10 +75,9 @@ export default function BookingDetailsDialog({
     return rescheduleOptions.filter((o) => o.hour * 60 + o.minute > startTotal);
   }, [rescheduleOptions, rescheduleStart]);
 
-  // Teachers available for transfer (excluding Alexandra)
   const otherTeachers = useMemo(() => {
     if (!booking) return [];
-    return teachers.filter((t) => t.firstName !== 'Alexandra' && t.id !== booking.adminId);
+    return teachers.filter((t) => t.id !== booking.adminId);
   }, [teachers, booking]);
 
   const handleClose = () => {

--- a/src/data/kodsidor.ts
+++ b/src/data/kodsidor.ts
@@ -1,0 +1,329 @@
+export type Platform = {
+  id: string;
+  name: string;
+  url: string;
+  description: string;
+  pros: string[];
+  cons: string[];
+  category: 'recommended' | 'complementary' | 'challenges' | 'minigames';
+};
+
+export const platforms: Platform[] = [
+  // ── Rekommenderade ──
+  {
+    id: 'freecodecamp',
+    name: 'FreeCodeCamp',
+    url: 'https://www.freecodecamp.org/learn',
+    description:
+      'En av de största gratisplattformarna för att lära sig webbutveckling. Omfattande kursplan som täcker HTML, CSS, JavaScript, React, Node.js och mer genom interaktiva övningar i webbläsaren.',
+    pros: [
+      'Helt gratis — inga dolda kostnader eller betalmurrar',
+      'Du bygger faktiska projekt som du kan lägga i portfolion',
+      'Stor och aktiv community — det finns alltid någon som svarar om du fastnar',
+      'Allt körs i webbläsaren, du behöver inte sätta upp någon miljö själv',
+    ],
+    cons: [
+      'Det är väldigt mycket text att läsa',
+    ],
+    category: 'recommended',
+  },
+  {
+    id: 'scrimba',
+    name: 'Scrimba',
+    url: 'https://www.scrimba.com',
+    description:
+      'Videobaserad plattform där du kan pausa och redigera kod direkt i lektionen. Förklarar tydligt och lär ut hur man bygger riktiga projekt med verktyg som GitHub och Netlify.',
+    pros: [
+      'Du kan pausa videon och skriva kod direkt i samma fönster — inte bara passiv tittning',
+      'Hjälper dig ta dig ur "tutorial hell" — projekten tvingar dig att tänka själv',
+      'Community där du kan få feedback på dina projekt från andra studenter',
+      'Bra för frontend och React — många hittar jobb efter karriärvägen',
+    ],
+    cons: [
+      'Kräver prenumeration för projektuppgifter',
+    ],
+    category: 'recommended',
+  },
+  {
+    id: 'sololearn',
+    name: 'SoloLearn',
+    url: 'https://www.sololearn.com',
+    description:
+      'Gamifierad plattform som börjar med enkla flervalsfrågor och gradvis övergår till att skriva kod. Fungerar bäst i mobilappen och är perfekt för att komma igång med kodning.',
+    pros: [
+      'Perfekt att starta med — korta lektioner, lätt att plocka upp telefonen och lära sig 10 min',
+      'Gamifierat med XP och badges — håller motivationen uppe',
+      'Täcker många språk på ett och samma ställe',
+      'Gratis basinnehåll utan irriterande reklam',
+    ],
+    cons: [
+      'För ytligt för att bli jobbredo — bra start men inte tillräckligt ensam',
+    ],
+    category: 'recommended',
+  },
+
+  // ── Kompletterande ──
+  {
+    id: 'khan-academy',
+    name: 'Khan Academy',
+    url: 'https://www.khanacademy.org/computing',
+    description:
+      'Gratis utbildningsplattform med videolektioner och interaktiva övningar. Finns på svenska och täcker grunderna i HTML, CSS och JavaScript.',
+    pros: [
+      'Helt gratis och tillgänglig direkt i webbläsaren — inga betalmurrar',
+      'Bra för nybörjare — förklarar grunderna med korta videor och interaktiva kodexempel',
+      'Kan lära i eget tempo, hoppa tillbaka och om utan press',
+    ],
+    cons: [
+      'Ingen community att ställa frågor till — du sitter ensam med videon',
+    ],
+    category: 'complementary',
+  },
+  {
+    id: 'frontend-mentor',
+    name: 'Frontend Mentor',
+    url: 'https://www.frontendmentor.io/',
+    description:
+      'Plattform med designutmaningar där du bygger verkliga projekt från designfiler. Perfekt för att träna på att omsätta en design till kod.',
+    pros: [
+      'Du bygger riktiga projekt från proffsiga designfiler — inte leksaksexempel',
+      'Bra för att träna på att "läsa en design och koda den", precis som på ett riktigt jobb',
+      'Gratis-nivån räcker långt för att komma igång',
+      'Perfekt för portfolioprojekt — ser bättre ut än ett todo-list-tutorial',
+      'Tydliga svårighetsnivåer så du vet vad du ger dig in på',
+    ],
+    cons: [
+      'Du får ingen feedback på dina lösningar',
+    ],
+    category: 'complementary',
+  },
+  {
+    id: 'odin-project',
+    name: 'The Odin Project',
+    url: 'https://www.theodinproject.com/',
+    description:
+      'Djup och rigorös kursplan som lär ut webbutveckling i VS Code med riktiga verktyg — Git, terminalen och lokala utvecklingsmiljöer. Community-driven och helt gratis.',
+    pros: [
+      'Komplett gratis-kurs från noll till junior webbutvecklare',
+      'Tvingar dig att tänka själv — du googlar och bygger som på jobbet',
+      'Stark Discord-community där folk faktiskt hjälper varandra',
+      'Lär ut Git, terminalen och riktiga arbetsflöden redan från start',
+      'Massor av framgångssagor — folk har fått jobb efter att ha kört igenom materialet',
+    ],
+    cons: [
+      'Ingen som håller handen — kan kännas överväldigande om du fastnar länge',
+      'Tar extremt mycket tid, räkna med hundratals timmar',
+    ],
+    category: 'complementary',
+  },
+  {
+    id: 'exercism',
+    name: 'Exercism',
+    url: 'https://exercism.org',
+    description:
+      'Plattform med kodövningar i 82 språk, inklusive JavaScript och TypeScript. Fokuserar på att skriva idiomatisk kod med frivillig mentorhjälp och automatisk analys.',
+    pros: [
+      'Gratis kodgranskning av riktiga, erfarna programmerare — unikt bland gratisplattformar',
+      'Kan se andras lösningar efter att du lämnat in — ger enorma "aha"-ögonblick',
+      'Stöd för väldigt många språk — bra om du vill prova något nytt',
+      'Community-forumet är vänligt och välkomnande',
+    ],
+    cons: [
+      'Inte bra som enda lärresurs — förutsätter att du redan kan grunderna i ett språk',
+    ],
+    category: 'complementary',
+  },
+
+  // ── Kodutmaningar ──
+  {
+    id: 'codewars',
+    name: 'Codewars',
+    url: 'https://www.codewars.com/',
+    description:
+      'Kodutmaningar (kata) med rangsystem inspirerat av kampsport. Efter varje löst uppgift kan man se andras lösningar och lära sig nya tekniker.',
+    pros: [
+      'Gratis och kör direkt i webbläsaren — inget att installera, bara köra igång',
+      'Ser andras lösningar efter varje kata — ofta det bästa sättet att lära sig skriva snyggare kod',
+      'Lätt att bli beroende (på ett bra sätt) — många kör en kata om dagen som en vana',
+      'Stödjer 55+ programmeringsspråk',
+    ],
+    cons: [
+      'Inte nybörjarvänligt',
+    ],
+    category: 'challenges',
+  },
+  {
+    id: 'leetcode',
+    name: 'LeetCode',
+    url: 'https://leetcode.com/',
+    description:
+      'Populär plattform för kodutmaningar, främst känd för intervjuförberedelser. Ren design och övningar i många språk, men riktar sig mot de som redan kan programmera.',
+    pros: [
+      'Bästa plattformen om du siktar på jobbintervjuer inom tech',
+      'Enorm mängd uppgifter — du börjar se mönster som dyker upp gång på gång',
+      'Stort community med diskussionstrådar och lösningar till nästan allt',
+    ],
+    cons: [
+      'Inte bra som nybörjarplattform — du behöver redan kunna grunderna',
+    ],
+    category: 'challenges',
+  },
+
+  // ── Minispel ──
+  {
+    id: 'flexbox-froggy',
+    name: 'Flexbox Froggy',
+    url: 'https://flexboxfroggy.com/',
+    description:
+      'Hjälp grodorna att nå sina näckrosor genom att skriva CSS Flexbox-kod. Ett populärt spel för att lära sig flexbox på ett visuellt och interaktivt sätt.',
+    pros: [
+      'Superkort och lätt att komma igång med — du spelar färdigt på under en timme',
+      'Visualiseringen är riktigt bra, du ser direkt vad din kod gör',
+      'Perfekt för nybörjare — ingen förkunskap krävs',
+    ],
+    cons: [
+      'Täcker inte allt inom flexbox — du lär dig grunderna men inte hela bilden',
+    ],
+    category: 'minigames',
+  },
+  {
+    id: 'grid-garden',
+    name: 'Grid Garden',
+    url: 'https://cssgridgarden.com/',
+    description:
+      'Vattna din trädgård genom att skriva CSS Grid-kod. Samma upplägg som Flexbox Froggy, fast för CSS Grid.',
+    pros: [
+      'Gör CSS Grid begripligt på ett sätt som är svårt att uppnå genom att bara läsa dokumentation',
+      'Bra för visuella lärare — du ser direkt hur vattnet rör sig när koden stämmer',
+      '28 nivåer ger lite mer substans än Flexbox Froggy',
+    ],
+    cons: [
+      'Ganska kort och ytlig — du lär dig grunderna men behöver öva mer på riktiga projekt',
+    ],
+    category: 'minigames',
+  },
+  {
+    id: 'anchoreum',
+    name: 'Anchoreum',
+    url: 'https://anchoreum.com/',
+    description:
+      'Lär dig CSS Anchor Positioning genom ett interaktivt spel. En nyare CSS-teknik som blir allt vanligare.',
+    pros: [
+      'Enda interaktiva resursen för CSS anchor positioning — ett ämne som nästan ingen annan täcker',
+      'Lär dig avancerade koncept, inte bara grunderna',
+      'Gratis, ingen registrering — du är igång direkt',
+    ],
+    cons: [],
+    category: 'minigames',
+  },
+  {
+    id: 'tailwind-trainer',
+    name: 'Tailwind Trainer',
+    url: 'https://codepip.com/games/tailwind-trainer/',
+    description:
+      'Öva på Tailwind CSS-klasser genom ett interaktivt spel. I beta — kräver ett Codepip-konto.',
+    pros: [
+      'Bygger på spaced repetition — du möter samma klasser flera gånger tills de sitter',
+      'Täcker brett: färger, spacing, typografi, flexbox, grid och mer',
+      'Varje session är lite annorlunda, så det känns inte repetitivt',
+    ],
+    cons: [
+      'Mer som ett quiz än ett spel',
+      'Kräver konto',
+    ],
+    category: 'minigames',
+  },
+  {
+    id: 'flexbox-zombies',
+    name: 'Flexbox Zombies',
+    url: 'https://flexboxzombies.com/',
+    description:
+      'Lär dig Flexbox genom att bekämpa zombier med CSS-kod. Pedagogiskt och visuellt imponerande med 12 kapitel.',
+    pros: [
+      'Går mycket djupare än Flexbox Froggy — du lär dig faktiskt hela flexbox',
+      'Berättelsen och karaktärerna gör att du faktiskt vill fortsätta spela',
+      'Spaced repetition inbyggt — du repeterar gamla koncept medan du lär dig nya',
+    ],
+    cons: [],
+    category: 'minigames',
+  },
+  {
+    id: 'service-workies',
+    name: 'Service Workies',
+    url: 'https://serviceworkies.com/',
+    description:
+      'Lär dig om Service Workers genom ett berättelsedrivet spel. Utvecklat i samarbete med Google.',
+    pros: [
+      'Riktigt spel med grafik, musik och story — inte bara en interaktiv tutorial',
+      'Service workers är notoriskt förvirrande — spelet gör livscykeln faktiskt begriplig',
+      'Gjort i samarbete med Google Developers, så innehållet är pålitligt',
+    ],
+    cons: [
+      'Ämnet är ganska nischat — du behöver förstå grunderna i webbutveckling först',
+      'Service workers används mest i PWA-projekt, vilket inte alla jobbar med',
+    ],
+    category: 'minigames',
+  },
+  {
+    id: 'css-diner',
+    name: 'CSS Diner',
+    url: 'https://flukeout.github.io/',
+    description:
+      'Lär dig CSS-selektorer genom att välja rätt element på en matbricka. Visar visuellt vilket element som HTML-koden syftar på.',
+    pros: [
+      'Täcker CSS-selektorer bättre än nästan vad som helst annat — från enkla till avancerade',
+      'Middagsbordsmetaforen är rolig och gör abstrakta selektorer konkreta',
+      'Gratis, direkt i webbläsaren, ingen inloggning',
+    ],
+    cons: [],
+    category: 'minigames',
+  },
+  {
+    id: 'flexbox-adventure',
+    name: 'Flexbox Adventure',
+    url: 'https://codingfantasy.com/',
+    description:
+      'Ett gamifierat äventyr där du lär dig Flexbox genom att styra riddare, magiker och skurkar med CSS-kod.',
+    pros: [
+      'Fantasy-berättelsen håller motivationen uppe på ett sätt som enkla layoutspel inte gör',
+      '24 nivåer med tydlig progression — bra för dig som gillar att se framsteg',
+      'Ger dig omedelbar visuell feedback när hjältarna hamnar rätt',
+    ],
+    cons: [
+      'Kräver konto',
+    ],
+    category: 'minigames',
+  },
+  {
+    id: 'grid-attack',
+    name: 'Grid Attack',
+    url: 'https://codingfantasy.com/',
+    description:
+      'Samma upplägg som Flexbox Adventure, fast för CSS Grid. Lär dig Grid genom att försvara din borg.',
+    pros: [
+      '80 nivåer — du hinner verkligen befästa CSS Grid, inte bara skumma ytan',
+      'Tre svårighetsnivåer gör att du kan utmana dig själv när grunderna sitter',
+      'Berättelsen om att rädda din bror håller dig engagerad',
+    ],
+    cons: [
+      'Kräver konto',
+    ],
+    category: 'minigames',
+  },
+  {
+    id: 'mcp-panic',
+    name: 'MCP Panic',
+    url: 'https://codingfantasy.com/',
+    description:
+      'Lär dig bygga MCP (Model Context Protocol) som AI-agenter använder för att kommunicera med externa tjänster som Gmail.',
+    pros: [
+      'Enda spelet som lär ut Model Context Protocol — extremt aktuellt ämne inom AI',
+      'Silicon Valley-satiren och berättelsen är genuint rolig',
+      'Du implementerar faktiska MCP-komponenter — inte bara teori',
+    ],
+    cons: [
+      'Kräver att du redan kan programmera — inte för nybörjare',
+    ],
+    category: 'minigames',
+  },
+];

--- a/src/pages/CoachBookingView.tsx
+++ b/src/pages/CoachBookingView.tsx
@@ -84,7 +84,7 @@ function CoachBookingView() {
 
   // Derived
   const admins = useMemo(() =>
-    allUsers.filter((u) => u.authLevel <= 2 && u.isActive && u.firstName !== 'Alexandra'),
+    allUsers.filter((u) => u.authLevel <= 2 && u.isActive),
     [allUsers]
   );
 

--- a/src/pages/CoachContact.tsx
+++ b/src/pages/CoachContact.tsx
@@ -5,7 +5,7 @@ import HelpDialog from "@/components/HelpDialog";
 const CoachContact = () => {
   const { data: allUsers = [], isLoading } = useUsers();
 
-  const admins = allUsers.filter((u) => u.authLevel <= 2 && u.isActive && u.firstName !== "Alexandra");
+  const admins = allUsers.filter((u) => u.authLevel <= 2 && u.isActive);
 
   if (isLoading) {
     return (

--- a/src/pages/Index.css
+++ b/src/pages/Index.css
@@ -39,6 +39,10 @@
   line-height: 1.6;
 }
 
+.index__hero-btn {
+  margin-top: 1rem;
+}
+
 .index__hero-bg {
   position: absolute;
   inset: 0;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { BookOpen, Calendar, Building, Users } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
 import heroImg from '@/assets/hero-classroom.jpg';
 import activitiesImg from '@/assets/activities.jpg';
 import facilitiesImg from '@/assets/facilities.jpg';
@@ -72,6 +74,9 @@ const Index = () => {
             Din väg in i tech börjar här. Lär dig koda, bygg projekt och forma
             din framtid – med stöd hela vägen.
           </p>
+          <Button asChild variant="secondary" className="index__hero-btn">
+            <Link to="/kodsidor">Utforska kodsidor</Link>
+          </Button>
         </div>
         <div className="index__hero-bg" />
       </motion.div>

--- a/src/pages/Kodsidor.css
+++ b/src/pages/Kodsidor.css
@@ -1,0 +1,265 @@
+.kodsidor {
+  padding: 4rem 15rem;
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+.kodsidor__title {
+  font-family: 'Raleway', sans-serif;
+  font-size: 1.7rem;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+  margin: 0 0 0.5rem 0;
+}
+
+.kodsidor__subtitle {
+  color: hsl(var(--muted-foreground));
+  font-size: 1rem;
+  margin: 0 0 1.5rem 0;
+}
+
+.kodsidor__tabs-list {
+  margin-bottom: 1.5rem;
+}
+
+/* Cards grid */
+.kodsidor__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+
+/* Card */
+.kodsidor__card {
+  background-color: hsl(var(--card));
+  border-radius: 1rem;
+  box-shadow: var(--shadow-card);
+  border: 1px solid hsl(var(--border));
+  padding: 1.25rem;
+  cursor: pointer;
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  transition:
+    box-shadow 0.3s ease,
+    transform 0.2s ease;
+}
+
+.kodsidor__card:hover {
+  box-shadow: var(--shadow-card-hover);
+}
+
+.kodsidor__card-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  min-width: 2.5rem;
+  border-radius: 0.75rem;
+  background: var(--gradient-hero);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.kodsidor__card-icon svg {
+  color: hsl(var(--primary-foreground));
+}
+
+.kodsidor__card-name {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: hsl(var(--card-foreground));
+  margin: 0 0 0.25rem 0;
+}
+
+.kodsidor__card-desc {
+  color: hsl(var(--muted-foreground));
+  font-size: 0.85rem;
+  line-height: 1.5;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Detail view */
+.kodsidor__detail {
+  max-width: 48rem;
+}
+
+.kodsidor__detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.kodsidor__detail-title {
+  font-family: 'Raleway', sans-serif;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+  margin: 0;
+}
+
+.kodsidor__detail-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: hsl(var(--primary));
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-decoration: none;
+  transition: opacity 0.2s;
+}
+
+.kodsidor__detail-link:hover {
+  opacity: 0.8;
+}
+
+.kodsidor__detail-desc {
+  color: hsl(var(--muted-foreground));
+  font-size: 0.95rem;
+  line-height: 1.7;
+  margin: 0 0 1.5rem 0;
+}
+
+.kodsidor__detail-lists {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.kodsidor__detail-section {
+  background-color: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+}
+
+.kodsidor__detail-section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.kodsidor__detail-section-header h3 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: hsl(var(--card-foreground));
+  margin: 0;
+}
+
+.kodsidor__detail-section--pros .kodsidor__detail-section-header svg {
+  color: hsl(142 71% 45%);
+}
+
+.kodsidor__detail-section--cons .kodsidor__detail-section-header svg {
+  color: hsl(0 84% 60%);
+}
+
+.kodsidor__detail-section ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.kodsidor__detail-section li {
+  color: hsl(var(--muted-foreground));
+  font-size: 0.875rem;
+  line-height: 1.5;
+  padding-left: 1.25rem;
+  position: relative;
+}
+
+.kodsidor__detail-section li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.55rem;
+  width: 0.35rem;
+  height: 0.35rem;
+  border-radius: 50%;
+}
+
+.kodsidor__detail-section--pros li::before {
+  background: hsl(142 71% 45%);
+}
+
+.kodsidor__detail-section--cons li::before {
+  background: hsl(0 84% 60%);
+}
+
+/* Responsive */
+@media (max-width: 1600px) {
+  .kodsidor {
+    padding: 1.3rem 4rem;
+  }
+}
+
+@media (max-width: 1000px) {
+  .kodsidor {
+    padding: 1rem 1rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .kodsidor {
+    padding: 1rem 2rem;
+  }
+
+  .kodsidor__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .kodsidor__title {
+    font-size: 1.3rem;
+  }
+
+  .kodsidor__tabs-list {
+    flex-wrap: wrap;
+    height: auto;
+  }
+}
+
+@media (max-width: 500px) {
+  .kodsidor {
+    padding: 1rem;
+  }
+
+  .kodsidor__title {
+    font-size: 1rem;
+  }
+
+  .kodsidor__card {
+    padding: 0.75rem;
+    border-radius: 8px;
+  }
+
+  .kodsidor__card-icon {
+    width: 2rem;
+    height: 2rem;
+    min-width: 2rem;
+    border-radius: 8px;
+  }
+
+  .kodsidor__card-name {
+    font-size: 0.85rem;
+  }
+
+  .kodsidor__card-desc {
+    font-size: 0.75rem;
+  }
+
+  .kodsidor__detail-section {
+    padding: 0.75rem;
+  }
+}

--- a/src/pages/Kodsidor.tsx
+++ b/src/pages/Kodsidor.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import { motion } from 'framer-motion';
+import { ArrowLeft, ExternalLink, ThumbsUp, ThumbsDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { platforms, type Platform } from '@/data/kodsidor';
+import './Kodsidor.css';
+
+const tabs = [
+  { value: 'recommended', label: 'Rekommenderade', category: 'recommended' as const },
+  { value: 'complementary', label: 'Kompletterande', category: 'complementary' as const },
+  { value: 'challenges', label: 'Kodutmaningar', category: 'challenges' as const },
+  { value: 'minigames', label: 'Minispel', category: 'minigames' as const },
+];
+
+const container = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.07 } },
+};
+
+const item = {
+  hidden: { opacity: 0, y: 16 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.4, ease: 'easeOut' as const } },
+};
+
+function PlatformDetail({ platform, onBack }: { platform: Platform; onBack: () => void }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: 20 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.3 }}
+      className="kodsidor__detail"
+    >
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onBack}
+        className="gap-2 text-muted-foreground mb-4"
+      >
+        <ArrowLeft className="h-4 w-4" /> Tillbaka
+      </Button>
+
+      <div className="kodsidor__detail-header">
+        <h2 className="kodsidor__detail-title">{platform.name}</h2>
+        <a
+          href={platform.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="kodsidor__detail-link"
+        >
+          Besök sidan <ExternalLink className="h-4 w-4" />
+        </a>
+      </div>
+
+      <p className="kodsidor__detail-desc">{platform.description}</p>
+
+      <div className="kodsidor__detail-lists">
+        {platform.pros.length > 0 && (
+          <div className="kodsidor__detail-section kodsidor__detail-section--pros">
+            <div className="kodsidor__detail-section-header">
+              <ThumbsUp className="h-4 w-4" />
+              <h3>Fördelar</h3>
+            </div>
+            <ul>
+              {platform.pros.map((pro, i) => (
+                <li key={i}>{pro}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {platform.cons.length > 0 && (
+          <div className="kodsidor__detail-section kodsidor__detail-section--cons">
+            <div className="kodsidor__detail-section-header">
+              <ThumbsDown className="h-4 w-4" />
+              <h3>Nackdelar</h3>
+            </div>
+            <ul>
+              {platform.cons.map((con, i) => (
+                <li key={i}>{con}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+const Kodsidor = () => {
+  const [selected, setSelected] = useState<Platform | null>(null);
+  const [activeTab, setActiveTab] = useState('recommended');
+
+  if (selected) {
+    return (
+      <div className="kodsidor">
+        <PlatformDetail platform={selected} onBack={() => setSelected(null)} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="kodsidor">
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        <h1 className="kodsidor__title">Kodsidor</h1>
+        <p className="kodsidor__subtitle">
+          Utforska plattformar och verktyg för att lära dig programmering och webbutveckling.
+        </p>
+      </motion.div>
+
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList className="kodsidor__tabs-list">
+          {tabs.map((tab) => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        {tabs.map((tab) => (
+          <TabsContent key={tab.value} value={tab.value}>
+            <motion.div
+              variants={container}
+              initial="hidden"
+              animate="show"
+              className="kodsidor__grid"
+              key={tab.value}
+            >
+              {platforms
+                .filter((p) => p.category === tab.category)
+                .map((platform) => (
+                  <motion.div
+                    key={platform.id}
+                    variants={item}
+                    className="kodsidor__card"
+                    onClick={() => setSelected(platform)}
+                  >
+                    <div className="kodsidor__card-icon">
+                      <ExternalLink className="h-4 w-4" />
+                    </div>
+                    <div>
+                      <h3 className="kodsidor__card-name">{platform.name}</h3>
+                      <p className="kodsidor__card-desc">{platform.description}</p>
+                    </div>
+                  </motion.div>
+                ))}
+            </motion.div>
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  );
+};
+
+export default Kodsidor;


### PR DESCRIPTION
## Summary
- New public `/kodsidor` page with 19 learning platforms across 4 tabs (Rekommenderade, Kompletterande, Kodutmaningar, Minispel)
- "Utforska kodsidor" button added to the landing page hero section
- Each platform card opens a detail view with description, pros/cons, and external link
- Route accessible without login (public, guest, and authenticated states)
- Removed hardcoded Alexandra filters from AdminSchedule, CoachAttendance, CoachBookingView, CoachContact, and BookingDetailsDialog

## Test plan
- [ ] Visit `/` as guest — verify "Utforska kodsidor" button appears in hero
- [ ] Click button — verify navigation to `/kodsidor`
- [ ] Switch between all 4 tabs — verify correct platforms in each
- [ ] Click a platform card — verify detail view with pros/cons and external link
- [ ] Click "Tillbaka" — verify return to tab view with same tab selected
- [ ] Visit `/kodsidor` directly without login — verify page loads
- [ ] Check coach contact list — verify Alexandra appears
- [ ] Check admin schedule — verify Alexandra appears in teacher list

🤖 Generated with [Claude Code](https://claude.com/claude-code)