### PR TITLE
feat: inline Om kursen and show start page for visitors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,13 +48,14 @@ function AppRoutes() {
     );
   }
 
-  // Not logged in and not guest → show login (but allow public pages)
+  // Not logged in and not guest → show start page (but allow public pages)
   if (!isLoggedIn && !isGuest) {
     return (
       <Routes>
+        <Route path="/" element={<AppLayout><Index /></AppLayout>} />
         <Route path="/login" element={<Login />} />
         <Route path="/kodsidor" element={<AppLayout><Kodsidor /></AppLayout>} />
-        <Route path="*" element={<Navigate to="/login" replace />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     );
   }

--- a/src/changelogs/2026-04-14-feat-inline-om-kursen.json
+++ b/src/changelogs/2026-04-14-feat-inline-om-kursen.json
@@ -1,0 +1,17 @@
+{
+  "displaydate": null,
+  "entries": {
+    "admin": [
+      "Startsidan visar nu kursinformation (Om kursen) direkt på sidan istället för i en dialog — med två kolumner för Spår 1 och Spår 2.",
+      "Kodsidor, Aktiviteter, Lokaler och Handledarna visas som kompakta minikort med bakgrundsbilder mellan hero-bannern och kursinnehållet.",
+      "Kodsidor-dialogen visar nu alla plattformar med beskrivningar och fördelar, grupperade per kategori.",
+      "Aktiviteter uppdaterade: JavaScript-föreläsning och Code Along borttagna, ny Tisdag-föreläsning/workshop tillagd.",
+      "Våra lokaler uppdaterade: ordningen ändrad till Spår 1, Spår 2, Spel & Häng och beskrivningar borttagna.",
+      "Besökare som inte är inloggade landar nu på startsidan istället för inloggningssidan."
+    ],
+    "coach": [
+      "Startsidan har fått en ny layout med kursinformation direkt synlig."
+    ],
+    "student": []
+  }
+}

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -104,11 +104,11 @@ export function AppSidebar({ mobileOpen, onMobileClose }: AppSidebarProps) {
   const [collapsed, setCollapsed] = useState(false);
   const location = useLocation();
   const navigate = useNavigate();
-  const { signOut, isGuest } = useAuth();
+  const { signOut, isLoggedIn } = useAuth();
   const { isAdmin, isCoach } = useUserRole();
   const { messagesCount, studentContextCount } = useUnreadCounts();
 
-  if (isGuest) return null;
+  if (!isLoggedIn) return null;
 
   const handleLogout = async () => {
     await signOut();

--- a/src/components/CardDialog.css
+++ b/src/components/CardDialog.css
@@ -264,3 +264,51 @@
   color: hsl(var(--muted-foreground));
   line-height: 1.5;
 }
+
+/* Kodsidor dialog */
+.cd-kodsidor .cd-block + .cd-block {
+  margin-top: 0.25rem;
+}
+.cd-platforms {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+.cd-platform {
+  background: hsl(var(--background));
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.5rem;
+  padding: 0.75rem 1rem;
+}
+.cd-platform-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+.cd-platform-header h4 {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: hsl(var(--foreground));
+}
+.cd-platform-link {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: hsl(var(--primary));
+  text-decoration: none;
+}
+.cd-platform-link:hover {
+  text-decoration: underline;
+}
+.cd-platform > p {
+  margin: 0 0 0.4rem 0;
+  font-size: 0.8rem;
+  color: hsl(var(--muted-foreground));
+  line-height: 1.5;
+}
+.cd-platform .cd-list {
+  margin: 0 0 0 1rem;
+  font-size: 0.8rem;
+  line-height: 1.6;
+}

--- a/src/components/CardDialog.tsx
+++ b/src/components/CardDialog.tsx
@@ -141,30 +141,16 @@ function AktiviteterContent() {
             <span className="cd-tag">Praktisk</span>
           </div>
         </div>
-        <div className="cd-activity cd-activity--wednesday">
+        <div className="cd-activity cd-activity--tuesday">
           <div className="cd-activity-head">
-            <span className="cd-activity-day">Onsdag</span>
-            <span className="cd-activity-time">11:00 - 12:00</span>
+            <span className="cd-activity-day">Tisdag</span>
+            <span className="cd-activity-time">13:00 - 14:00</span>
           </div>
-          <h4>JavaScript-föreläsning</h4>
-          <p>Veckovis föreläsningar om JavaScript-koncept.</p>
-          <div className="cd-activity-leader"><strong>Ledare:</strong> Victoria &amp; Adam</div>
+          <h4>Föreläsning/Workshop</h4>
+          <p>Veckovisa föreläsningar/workshops om programmering.</p>
           <div className="cd-tags">
-            <span className="cd-tag">JavaScript</span>
-            <span className="cd-tag">Föreläsning</span>
-          </div>
-        </div>
-        <div className="cd-activity cd-activity--thursday">
-          <div className="cd-activity-head">
-            <span className="cd-activity-day">Torsdag</span>
-            <span className="cd-activity-time">13:00 - 14:30</span>
-          </div>
-          <h4>Code Along - Praktisk Programmering</h4>
-          <p>Vi kodar tillsammans och bygger projekt.</p>
-          <div className="cd-activity-leader"><strong>Plattform:</strong> Microsoft Teams</div>
-          <div className="cd-tags">
-            <span className="cd-tag">Praktisk</span>
-            <span className="cd-tag">Code Along</span>
+            <span className="cd-tag">Programmering</span>
+            <span className="cd-tag">Workshop</span>
           </div>
         </div>
         <div className="cd-activity cd-activity--social">
@@ -221,15 +207,14 @@ function LokalerContent() {
       </p>
       <div className="cd-locales">
         {[
-          { title: "Spår 2 - Klassrum", desc: "Ett lugnt klassrum för att utforska programmering." },
-          { title: "Spel & Häng - Socialt Rum", desc: "Mysigt rum för onsdagshäng med spel." },
-          { title: "Spår 1 - Avancerat Arbetsrum", desc: "Professionellt arbetsrum med kraftfulla datorer." },
+          { title: "Spår 1" },
+          { title: "Spår 2" },
+          { title: "Spel & Häng - Socialt Rum" },
         ].map((loc) => (
           <div key={loc.title} className="cd-locale">
             <img src={facilitiesImg} alt={loc.title} className="cd-locale-img" />
             <div className="cd-locale-info">
               <h4>{loc.title}</h4>
-              <p>{loc.desc}</p>
             </div>
           </div>
         ))}
@@ -260,11 +245,219 @@ function HandledarnaContent() {
   );
 }
 
+const kodsidorCategories = [
+  {
+    title: "Rekommenderade",
+    platforms: [
+      {
+        name: "FreeCodeCamp",
+        url: "https://www.freecodecamp.org/learn",
+        description: "En av de största gratisplattformarna för att lära sig webbutveckling.",
+        highlights: [
+          "Helt gratis — inga dolda kostnader eller betalmurrar",
+          "Du bygger faktiska projekt som du kan lägga i portfolion",
+          "Stor och aktiv community",
+          "Allt körs i webbläsaren",
+        ],
+      },
+      {
+        name: "Scrimba",
+        url: "https://www.scrimba.com",
+        description: "Videobaserad plattform där du kan pausa och redigera kod direkt i lektionen.",
+        highlights: [
+          "Videobaserade kurser",
+          "Pausa videon och skriv kod direkt i samma fönster",
+        ],
+      },
+      {
+        name: "SoloLearn",
+        url: "https://www.sololearn.com",
+        description: "Gamifierad plattform, perfekt för att komma igång med kodning.",
+        highlights: [
+          "Korta lektioner - cirka 10 minuter",
+          "Passar också bra på mobilen på bussen på vägen till skolan",
+          "Gamifierat med XP och badges",
+        ],
+      },
+    ],
+  },
+  {
+    title: "Kompletterande",
+    platforms: [
+      {
+        name: "Khan Academy",
+        url: "https://www.khanacademy.org/computing",
+        description: "Gratis videolektioner och interaktiva övningar. Finns på svenska.",
+        highlights: [
+          "Helt gratis och tillgänglig direkt i webbläsaren",
+          "Bra för nybörjare med korta videor och interaktiva kodexempel",
+          "Lär i eget tempo utan press",
+        ],
+      },
+      {
+        name: "Frontend Mentor",
+        url: "https://www.frontendmentor.io/",
+        description: "Designutmaningar där du bygger verkliga projekt från designfiler.",
+        highlights: [
+          "Riktiga projekt från proffsiga designfiler",
+          "Träna på att läsa en design och koda den",
+          "Perfekt för portfolioprojekt",
+          "Tydliga svårighetsnivåer",
+        ],
+      },
+      {
+        name: "The Odin Project",
+        url: "https://www.theodinproject.com/",
+        description: "Djup kursplan som lär ut webbutveckling med riktiga verktyg.",
+        highlights: [
+          "Komplett gratis-kurs från noll till junior webbutvecklare",
+          "Lär ut Git, terminalen och riktiga arbetsflöden",
+          "Kräver eget driv — du söker svar och löser problem själv, precis som på ett riktigt jobb",
+        ],
+      },
+      {
+        name: "Exercism",
+        url: "https://exercism.org",
+        description: "Kodövningar i 82 språk med frivillig mentorhjälp.",
+        highlights: [
+          "Gratis kodgranskning av erfarna programmerare",
+          "Se andras lösningar efter att du lämnat in",
+          "Brant svårighetskurva — utmanande övningar som verkligen testar din förståelse",
+        ],
+      },
+    ],
+  },
+  {
+    title: "Kodutmaningar",
+    platforms: [
+      {
+        name: "Codewars",
+        url: "https://www.codewars.com/",
+        description: "Kodutmaningar med rangsystem inspirerat av kampsport.",
+        highlights: [
+          "Kör direkt i webbläsaren — bara köra igång",
+          "Se andras lösningar efter varje övning",
+          "Stödjer 55+ programmeringsspråk",
+        ],
+      },
+      {
+        name: "LeetCode",
+        url: "https://leetcode.com/",
+        description: "Populär plattform för kodutmaningar och intervjuförberedelser.",
+        highlights: [
+          "Bästa plattformen för jobbintervjuer inom tech",
+          "Enorm mängd uppgifter — du börjar se mönster",
+          "Stort community med diskussionstrådar",
+          "Inte lämplig för nybörjare",
+        ],
+      },
+    ],
+  },
+  {
+    title: "Minispel",
+    platforms: [
+      {
+        name: "Flexbox Froggy",
+        url: "https://flexboxfroggy.com/",
+        description: "Lär dig CSS Flexbox genom att hjälpa grodor nå sina näckrosor.",
+        highlights: [],
+      },
+      {
+        name: "Grid Garden",
+        url: "https://cssgridgarden.com/",
+        description: "Lär dig CSS Grid genom att vattna din trädgård.",
+        highlights: [],
+      },
+      {
+        name: "CSS Diner",
+        url: "https://flukeout.github.io/",
+        description: "Lär dig CSS-selektorer genom att välja rätt element på en matbricka.",
+        highlights: [],
+      },
+      {
+        name: "Flexbox Zombies",
+        url: "https://flexboxzombies.com/",
+        description: "Lär dig Flexbox genom att bekämpa zombier med CSS-kod.",
+        highlights: [],
+      },
+      {
+        name: "Flexbox Adventure",
+        url: "https://codingfantasy.com/",
+        description: "Gamifierat äventyr där du styr riddare med Flexbox-kod.",
+        highlights: [],
+      },
+      {
+        name: "Grid Attack",
+        url: "https://codingfantasy.com/",
+        description: "Lär dig CSS Grid genom att försvara din borg.",
+        highlights: [],
+      },
+      {
+        name: "Anchoreum",
+        url: "https://anchoreum.com/",
+        description: "Lär dig CSS Anchor Positioning genom ett interaktivt spel.",
+        highlights: [],
+      },
+      {
+        name: "Tailwind Trainer",
+        url: "https://codepip.com/games/tailwind-trainer/",
+        description: "Öva Tailwind CSS-klasser genom ett interaktivt spel.",
+        highlights: [],
+      },
+      {
+        name: "Service Workies",
+        url: "https://serviceworkies.com/",
+        description: "Lär dig Service Workers genom ett berättelsedrivet spel.",
+        highlights: [],
+      },
+      {
+        name: "MCP Panic",
+        url: "https://codingfantasy.com/",
+        description: "Lär dig bygga MCP som AI-agenter använder.",
+        highlights: [],
+      },
+    ],
+  },
+];
+
+function KodsidorContent() {
+  return (
+    <div className="cd-section cd-kodsidor">
+      <p className="cd-intro">
+        Plattformar och verktyg för att lära dig programmering och webbutveckling.
+      </p>
+      {kodsidorCategories.map((cat) => (
+        <div key={cat.title} className="cd-block">
+          <h3>{cat.title}</h3>
+          <div className="cd-platforms">
+            {cat.platforms.map((p) => (
+              <div key={p.name} className="cd-platform">
+                <div className="cd-platform-header">
+                  <h4>{p.name}</h4>
+                  <a href={p.url} target="_blank" rel="noopener noreferrer" className="cd-platform-link">
+                    Besök
+                  </a>
+                </div>
+                <p>{p.description}</p>
+                <ul className="cd-list">
+                  {p.highlights.map((h, i) => (
+                    <li key={i}>{h}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 const dialogContent: Record<
   string,
   { title: string; component: () => React.ReactElement }
 > = {
-  "Om kursen": { title: "Om Kursen", component: OmKursenContent },
+  "Kodsidor": { title: "Kodsidor", component: KodsidorContent },
   "Våra aktiviteter": { title: "Kursaktiviteter", component: AktiviteterContent },
   "Våra lokaler": { title: "Våra Lokaler", component: LokalerContent },
   Handledarna: { title: "Våra Lärare", component: HandledarnaContent },

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -69,7 +69,7 @@ export function TopNav({ onMenuToggle }: TopNavProps) {
               {initials}
             </div>
           )
-        ) : isGuest ? (
+        ) : (
           <Button
             variant="outline"
             size="sm"
@@ -79,7 +79,7 @@ export function TopNav({ onMenuToggle }: TopNavProps) {
             <LogIn className="h-4 w-4" />
             Logga in
           </Button>
-        ) : null}
+        )}
       </div>
     </header>
   );

--- a/src/pages/Index.css
+++ b/src/pages/Index.css
@@ -48,85 +48,222 @@
   inset: 0;
 }
 
-/* Cards grid */
-.index__grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1.5rem;
-}
-
-/* Card */
-.index__card {
+/* About section (Om kursen inline) */
+.index__about {
   background-color: hsl(var(--card));
   border-radius: 1rem;
-  box-shadow: var(--shadow-card);
-  overflow: hidden;
   border: 1px solid hsl(var(--border));
+  box-shadow: var(--shadow-card);
+  padding: 2rem;
+}
+
+.index__about-intro {
+  font-family: 'Raleway', sans-serif;
+  font-style: italic;
+  color: hsl(var(--muted-foreground));
+  font-size: 1.05rem;
+  line-height: 1.7;
+  margin: 0 0 1.5rem 0;
+  text-align: center;
+  max-width: 48rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.index__about-tracks {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+.index__about-track {
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  background: hsl(var(--muted) / 0.4);
+  border: 1px solid hsl(var(--border));
+}
+
+.index__about-track h3 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: hsl(var(--card-foreground));
+  margin: 0 0 0.25rem 0;
+}
+
+.index__about-track-sub {
+  color: hsl(var(--primary));
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin: 0 0 0.75rem 0;
+}
+
+.index__about-track h4 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: hsl(var(--card-foreground));
+  margin: 1rem 0 0.5rem 0;
+}
+
+.index__about-track p {
+  color: hsl(var(--muted-foreground));
+  font-size: 0.875rem;
+  line-height: 1.6;
+  margin: 0 0 0.5rem 0;
+}
+
+.index__about-track ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.75rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.index__about-track ul li {
+  color: hsl(var(--muted-foreground));
+  font-size: 0.85rem;
+  line-height: 1.5;
+  padding-left: 1.25rem;
+  position: relative;
+}
+
+.index__about-track ul li::before {
+  content: '→';
+  position: absolute;
+  left: 0;
+  color: hsl(var(--primary));
+}
+
+.index__about-target {
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  background: hsl(var(--muted) / 0.4);
+  border: 1px solid hsl(var(--border));
+  text-align: center;
+  max-width: 36rem;
+  margin: 0 auto 1.5rem;
+}
+
+.index__about-target h3 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: hsl(var(--card-foreground));
+  margin: 0 0 0.5rem 0;
+}
+
+.index__about-target p {
+  color: hsl(var(--muted-foreground));
+  font-size: 0.875rem;
+  line-height: 1.6;
+  margin: 0 0 0.5rem 0;
+}
+
+.index__about-why {
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  background: var(--gradient-hero);
+  color: hsl(var(--primary-foreground));
+}
+
+.index__about-why h3 {
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin: 0 0 0.75rem 0;
+}
+
+.index__about-why ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.index__about-why ul li {
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: hsl(var(--primary-foreground) / 0.9);
+}
+
+.index__about-why > p {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  margin: 0;
+  color: hsl(var(--primary-foreground) / 0.85);
+}
+
+/* Mini cards row */
+.index__minicards {
+  display: flex;
+  gap: 1rem;
+}
+
+.index__minicard {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid hsl(var(--border));
+  box-shadow: var(--shadow-card);
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  background-size: cover;
+  background-position: center;
   transition:
     box-shadow 0.3s ease,
     transform 0.2s ease;
-  cursor: pointer;
 }
 
-.index__card:hover {
+.index__minicard::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: hsl(var(--card) / 0.8);
+  transition: background 0.3s ease;
+}
+
+.index__minicard:hover {
   box-shadow: var(--shadow-card-hover);
+  transform: translateY(-1px);
 }
 
-.index__card-image-wrap {
-  height: 11rem;
-  overflow: hidden;
+.index__minicard:hover::before {
+  background: hsl(var(--card) / 0.65);
 }
 
-.index__card-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.5s ease;
-}
-
-.index__card:hover .index__card-image {
-  transform: scale(1.05);
-}
-
-.index__card-body {
-  padding: 0.8rem;
-}
-
-.index__card-header {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.index__card-icon {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 0.75rem;
+.index__minicard-icon {
+  position: relative;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.5rem;
   background: var(--gradient-hero);
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 }
 
-.index__card-icon svg {
-  width: 1.25rem;
-  height: 1.25rem;
+.index__minicard-icon svg {
+  width: 1.1rem;
+  height: 1.1rem;
   color: hsl(var(--primary-foreground));
 }
 
-.index__card-title {
+.index__minicard-title {
+  position: relative;
   font-family: 'Space Grotesk', sans-serif;
   font-weight: 600;
-  font-size: 1.125rem;
+  font-size: 0.9rem;
   color: hsl(var(--card-foreground));
-  margin: 0;
-}
-
-.index__card-desc {
-  color: hsl(var(--muted-foreground));
-  font-size: 0.875rem;
-  line-height: 1.625;
-  margin: 0;
 }
 
 @media (max-width: 1600px) {
@@ -142,9 +279,10 @@
     font-size: 1.5rem;
   }
 
-  .index__card-image-wrap {
-    height: 7rem;
+  .index__about {
+    padding: 1.5rem;
   }
+
 }
 
 @media (max-width: 1000px) {
@@ -158,16 +296,29 @@
     padding: 1rem 2rem;
   }
 
-  .index__grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
   .index__hero-title {
     font-size: 1.3rem;
   }
 
   .index__hero-text {
     font-size: 0.8rem;
+  }
+
+  .index__minicards {
+    flex-wrap: wrap;
+  }
+
+  .index__minicard {
+    flex: 0 0 calc(50% - 0.5rem);
+  }
+
+  .index__about-tracks {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .index__about-why ul {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -176,9 +327,30 @@
     padding: 1rem;
     gap: 1rem;
   }
-  .index__grid {
-    grid-template-columns: 1fr;
-    gap: 1rem;
+  .index__minicards {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+
+  .index__minicard {
+    padding: 0.5rem 0.75rem;
+    border-radius: 8px;
+  }
+
+  .index__minicard-icon {
+    width: 1.6rem;
+    height: 1.6rem;
+    border-radius: 6px;
+  }
+
+  .index__minicard-icon svg {
+    width: 0.9rem;
+    height: 0.9rem;
+  }
+
+  .index__minicard-title {
+    font-size: 0.75rem;
   }
 
   .index__hero {
@@ -194,31 +366,16 @@
     display: none;
   }
 
-  .index__card {
+  .index__about {
+    padding: 1rem;
     border-radius: 8px;
   }
 
-  .index__card-image-wrap {
-    height: 6rem;
+  .index__about-track {
+    padding: 1rem;
   }
 
-  .index__card-body {
-    padding: 0.5rem;
-  }
-
-  .index__card-icon {
-    border-radius: 8px;
-    height: 1.8rem;
-    width: 1.8rem;
-  }
-
-  .index__card-icon svg {
-    width: 1rem;
-    height: 1rem;
-    color: hsl(var(--primary-foreground));
-  }
-
-  .index__card-title {
-    font-size: 0.8rem;
+  .index__about-why {
+    padding: 1rem;
   }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
-import { BookOpen, Calendar, Building, Users } from 'lucide-react';
-import { Link } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
+import { Code, Calendar, Building, Users } from 'lucide-react';
 import heroImg from '@/assets/hero-classroom.jpg';
 import activitiesImg from '@/assets/activities.jpg';
 import facilitiesImg from '@/assets/facilities.jpg';
@@ -11,34 +9,10 @@ import CardDialog from '@/components/CardDialog';
 import './Index.css';
 
 const cards = [
-  {
-    title: 'Om kursen',
-    description:
-      'Lär dig programmering från grunden med modern pedagogik, praktiska projekt och stöd hela vägen till anställning.',
-    icon: BookOpen,
-    image: heroImg,
-  },
-  {
-    title: 'Våra aktiviteter',
-    description:
-      'Workshops, hackathons, gästföreläsningar och branschevent som ger dig verkliga kontakter och erfarenheter.',
-    icon: Calendar,
-    image: activitiesImg,
-  },
-  {
-    title: 'Våra lokaler',
-    description:
-      'Moderna, ljusa lokaler med allt du behöver – höghastighetsinternet, dual monitors och samarbetsytor.',
-    icon: Building,
-    image: facilitiesImg,
-  },
-  {
-    title: 'Handledarna',
-    description:
-      'Erfarna utvecklare och pedagoger som brinner för att hjälpa dig nå dina mål inom programmering.',
-    icon: Users,
-    image: instructorsImg,
-  },
+  { title: 'Kodsidor', icon: Code, image: heroImg },
+  { title: 'Våra aktiviteter', icon: Calendar, image: activitiesImg },
+  { title: 'Våra lokaler', icon: Building, image: facilitiesImg },
+  { title: 'Handledarna', icon: Users, image: instructorsImg },
 ];
 
 const container = {
@@ -74,9 +48,6 @@ const Index = () => {
             Din väg in i tech börjar här. Lär dig koda, bygg projekt och forma
             din framtid – med stöd hela vägen.
           </p>
-          <Button asChild variant="secondary" className="index__hero-btn">
-            <Link to="/kodsidor">Utforska kodsidor</Link>
-          </Button>
         </div>
         <div className="index__hero-bg" />
       </motion.div>
@@ -85,35 +56,114 @@ const Index = () => {
         variants={container}
         initial="hidden"
         animate="show"
-        className="index__grid"
+        className="index__minicards"
       >
         {cards.map((card) => (
           <motion.div
             key={card.title}
             variants={item}
-            className="index__card"
+            className="index__minicard"
             onClick={() => setOpenCard(card.title)}
-            style={{ cursor: 'pointer' }}
+            style={{ backgroundImage: `url(${card.image})` }}
           >
-            <div className="index__card-image-wrap">
-              <img
-                src={card.image}
-                alt={card.title}
-                className="index__card-image"
-                loading="lazy"
-              />
+            <div className="index__minicard-icon">
+              <card.icon />
             </div>
-            <div className="index__card-body">
-              <div className="index__card-header">
-                <div className="index__card-icon">
-                  <card.icon />
-                </div>
-                <h3 className="index__card-title">{card.title}</h3>
-              </div>
-            </div>
+            <span className="index__minicard-title">{card.title}</span>
           </motion.div>
         ))}
       </motion.div>
+
+      <motion.section
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, delay: 0.15 }}
+        className="index__about"
+      >
+        <p className="index__about-intro">
+          Hos oss erbjuder vi en unik och inkluderande programmeringsmiljö där du
+          kan utvecklas i din egen takt, på dina egna villkor. Vi tror på att alla
+          kan lära sig programmera – det handlar bara om att hitta rätt stöd och
+          miljö.
+        </p>
+
+        <div className="index__about-tracks">
+          <div className="index__about-track">
+            <h3>Spår 1: Upptäck Programmering</h3>
+            <p className="index__about-track-sub">
+              För dig som vill utforska kodningens värld
+            </p>
+            <p>
+              Är du nyfiken på programmering men osäker på om det är något för
+              dig? Vårt upptäcksspår ger dig möjlighet att prova på kodning i en
+              trygg och stödjande miljö – helt utan förkunskaper.
+            </p>
+            <h4>Detta erbjuder vi dig:</h4>
+            <ul>
+              <li><strong>Ingen press:</strong> Lär dig i din egen takt, utan krav på daglig närvaro</li>
+              <li><strong>Lugn miljö:</strong> En stödjande atmosfär där misstag är en del av lärandet</li>
+              <li><strong>Individuell anpassning:</strong> Vi gör alla möjliga anpassningar för dina specifika behov</li>
+              <li><strong>Inga förkunskaper krävs:</strong> Du börjar från grunden, oavsett bakgrund</li>
+              <li><strong>Utrustning ingår:</strong> Vi har datorer du kan låna under hela kursen</li>
+              <li><strong>Flexibel närvaro:</strong> Kom när det passar dig, utan stress eller förväntningar</li>
+            </ul>
+          </div>
+
+          <div className="index__about-track">
+            <h3>Spår 2: Avancerad Utveckling</h3>
+            <p className="index__about-track-sub">
+              För dig som vill ta nästa steg i karriären
+            </p>
+            <p>
+              Har du redan lärt dig grunderna i programmering och känner att du är
+              redo att ta nästa steg? Vårt avancerade spår är utformat för dig som
+              vill förbereda dig för professionell utveckling.
+            </p>
+            <h4>Vad du får:</h4>
+            <ul>
+              <li>Mentorskap från erfarna utvecklare</li>
+              <li>Praktiska projekt som speglar verkliga arbetsuppgifter</li>
+              <li>Vägledning mot mentorskap eller praktikplats hos etablerade företag</li>
+              <li>Möjlighet att bygga en professionell portfolio</li>
+              <li>Nätverk med branschkontakter</li>
+            </ul>
+            <p>
+              <strong>Målet:</strong> Att förbereda dig för en karriär inom
+              mjukvaruutveckling genom praktisk erfarenhet och professionella
+              kontakter.
+            </p>
+          </div>
+        </div>
+
+        <div className="index__about-target">
+          <h3>Vår målgrupp</h3>
+          <p>
+            Vi vänder oss särskilt till dig som har upplevt att den traditionella
+            skolvägen inte fungerat för dig. Här får du chansen att upptäcka
+            programmering i en miljö som är byggd för just dig.
+          </p>
+          <p>
+            <strong>Målet:</strong> Att ge dig möjlighet att upptäcka om
+            programmering är något du vill fortsätta med, utan press eller
+            förväntningar.
+          </p>
+        </div>
+
+        <div className="index__about-why">
+          <h3>Varför välja CUL Programmering?</h3>
+          <ul>
+            <li><strong>Flexibilitet:</strong> Anpassa dina studier efter ditt liv, inte tvärtom</li>
+            <li><strong>Stöd:</strong> Erfarna mentorer som bryr sig om din utveckling</li>
+            <li><strong>Inkludering:</strong> Alla är välkomna, oavsett bakgrund eller förutsättningar</li>
+            <li><strong>Praktiskt:</strong> Verkliga projekt och hands-on erfarenhet</li>
+          </ul>
+          <p>
+            Redo att ta första steget? Oavsett om du vill bygga en karriär inom
+            utveckling eller bara är nyfiken på vad kodning innebär, har vi en
+            plats för dig!
+          </p>
+        </div>
+      </motion.section>
 
       <CardDialog
         cardTitle={openCard ?? ''}


### PR DESCRIPTION
## Summary
- Move course info (Spår 1/2, Vår målgrupp, Varför välja CUL) directly onto the start page instead of behind a dialog
- Replace image card grid with compact icon+title minicards with background images
- Populate Kodsidor dialog with all platforms grouped by category (pros only, no cons)
- Update activities (remove JS-föreläsning & Code Along, add Tisdag workshop) and lokaler content
- Unauthenticated visitors now land on the start page with login button in top nav, no sidebar

## Test plan
- [ ] Visit site without logging in — should see start page, not login
- [ ] Verify no sidebar shown for unauthenticated visitors
- [ ] Click "Logga in" button in top right — should navigate to login page
- [ ] Click each minicard — dialogs open correctly
- [ ] Verify Kodsidor dialog shows all platforms with highlights
- [ ] Log in — verify sidebar appears and full navigation works
- [ ] Check responsive layout on mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)