### PR TITLE
Datorer tabs, Spår 2 layout, stats rework + attendance fixes

### DIFF
--- a/src/changelogs/2026-06-05-claude-hopeful-goldstine-ed99ab.json
+++ b/src/changelogs/2026-06-05-claude-hopeful-goldstine-ed99ab.json
@@ -1,0 +1,21 @@
+{
+  "displaydate": null,
+  "entries": {
+    "admin": [
+      "Spår 2 i klassrumsvyn har nu tre bordsrader — en ny mittenrad med ett bord vid högra väggen och ett nytt bord i mitten av nedersta raden.",
+      "Datorer-sidan är uppdelad i två flikar: \"Delade datorer\" och \"Egen dator\", där egna datorer visas två kort per rad.",
+      "Statistik → Datorer: \"Antal tilldelade datorer\" heter nu \"Antal utlånade\", \"Antal delade datorer\" heter \"Antal delvis bokade\", och en ny rad \"Antal helt obokade\" visar hur många datorer som är lediga att låna ut.",
+      "Statistik → Närvaro: kolumnen för standardavvikelse är borttagen.",
+      "Statistik-fliken under Deltagare är borttagen — Startdatum, Senaste närvarodag och Närvaro per månad visas nu direkt under Närvaro-fliken.",
+      "Närvaro per månad visar nu månaderna som rader med två kolumner: antal närvarodagar och närvaro i procent utifrån schemalagda dagar.",
+      "Buggfix: \"Senaste närvarodag\" tittar nu tillbaka hela vägen till deltagarens startdatum istället för bara de senaste veckorna.",
+      "Buggfix: när ett möte tackas ja till å en annan lärares vägnar får nu den läraren ett e-postmeddelande om att mötet tilldelats hen (tidigare fick bara coachen besked)."
+    ],
+    "coach": [
+      "Statistik-fliken för dina deltagare är borttagen — startdatum, senaste närvarodag och närvaro per månad visas nu under Närvaro-fliken istället.",
+      "Närvaro per månad visar nu månaderna som rader med antal närvarodagar och närvaro i procent utifrån schemalagda dagar.",
+      "Buggfix: \"Senaste närvarodag\" tittar nu tillbaka hela vägen till deltagarens startdatum istället för bara de senaste veckorna."
+    ],
+    "student": []
+  }
+}

--- a/src/components/admin/CoachAttendance.tsx
+++ b/src/components/admin/CoachAttendance.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState } from "react";
 import HelpDialog from "@/components/HelpDialog";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -68,11 +68,24 @@ const CoachAttendance: React.FC<CoachAttendanceProps> = ({ seluser = null, showC
   const [selectedUserId, setSelectedUserId] = useState<number>(seluser?.id || 0);
   const [selectedCoachId, setSelectedCoachId] = useState<number>(seluser?.coachId ?? 0);
   const [activeTab, setActiveTab] = useState("narvaro");
+  // Stable "today" anchor for the wide stats query below (a fresh Date() each render
+  // would change the query key and refetch in a loop).
+  const [statsAnchor] = useState(() => new Date());
 
   const { toast } = useToast();
 
   const { data: users = [], isLoading: isUsersLoading, isError: isUsersError, error: usersError, refetch: refetchUsers, isFetching: isUsersFetching } = useUsers();
   const { data: attendance = [] as AttendanceType[], isLoading: isAttendanceLoading, isError: isAttendanceError, error: attendanceError, refetch: refetchAttendance, isRefetching: isAttendanceRefetching } = useAttendance(date, 2);
+  // The grid query above only spans 2 weeks. The summary below the grid (Senaste
+  // närvarodag, Närvaro per månad) needs the participant's full history, so fetch a
+  // window wide enough to reach back to their start date (weeks = whole enrolment,
+  // floored at 16 to always cover the 3-month table, capped at ~5 years).
+  const statsWeeks = Math.min(260, Math.max(16,
+    selectedUser?.startDate
+      ? Math.ceil((statsAnchor.getTime() - new Date(selectedUser.startDate).getTime()) / (7 * 86_400_000)) + 1
+      : 0
+  ));
+  const { data: statsAttendance = [] as AttendanceType[] } = useAttendance(statsAnchor, statsWeeks);
   const { data: noClasses = [] as Date[], isLoading: isNoClassesLoading, isError: isNoClassesError, error: noClassesError, refetch: refetchNoClasses, isRefetching: isNoClassesRefetching } = useNoClasses();
   const updateUserMutation = useUpdateUser();
   const { data: week } = useGetWeek(date, 2);
@@ -200,82 +213,22 @@ const CoachAttendance: React.FC<CoachAttendanceProps> = ({ seluser = null, showC
     const scheduledSet = new Set(
       getScheduledDatesInRange(start, end).map((d) => d.toISOString().slice(0, 10))
     );
-    return attendance
+    return statsAttendance
       .filter((att) => att.userId === selectedUser.id)
       .flatMap((att) => att.date)
       .map((d) => new Date(d))
       .filter((d) => d >= start && d <= end && scheduledSet.has(d.toISOString().slice(0, 10)));
   };
 
-  const printScheduledDays = (offset: number): string => {
-    if (!selectedUser) return "";
+  const monthStats = (offset: number): { attended: number; scheduled: number; pct: number } => {
+    if (!selectedUser) return { attended: 0, scheduled: 0, pct: 0 };
     const start = getFirstDayOfMonth(offset);
     const end = getLastDayOfMonth(offset);
-    const attendedDays = getAttendedDatesInRange(start, end).length;
-    const totalScheduled = getScheduledDatesInRange(start, end).length;
-    return `${attendedDays} / ${totalScheduled} (${totalScheduled > 0 ? Math.round((attendedDays / totalScheduled) * 100) : 0}%)`;
+    const attended = getAttendedDatesInRange(start, end).length;
+    const scheduled = getScheduledDatesInRange(start, end).length;
+    const pct = scheduled > 0 ? Math.round((attended / scheduled) * 100) : 0;
+    return { attended, scheduled, pct };
   };
-
-  // Memoize 3-month stats to avoid recomputing on every render
-  const threeMonthStats = useMemo(() => {
-    if (!selectedUser) return null;
-    const start = getFirstDayOfMonth(-2);
-    const end = getLastDayOfMonth(0);
-    const scheduled = getScheduledDatesInRange(start, end);
-    const attended = getAttendedDatesInRange(start, end);
-    const attendedSet = new Set(attended.map((d) => d.toISOString().slice(0, 10)));
-
-    // Aggregate
-    const pct = scheduled.length > 0 ? Math.round((attended.length / scheduled.length) * 100) : 0;
-    const aggregate = `${attended.length} / ${scheduled.length} (${pct}%)`;
-
-    // Absence by weekday
-    const weekdays = ["måndag", "tisdag", "onsdag", "torsdag"];
-    const labels = ["Måndag", "Tisdag", "Onsdag", "Torsdag"];
-    const absenceByWeekday = weekdays
-      .map((wd, i) => {
-        const total = scheduled.filter((d) => getWeekday(d) === wd).length;
-        if (total === 0) return null;
-        const present = attended.filter((d) => getWeekday(d) === wd).length;
-        return { label: labels[i], missed: total - present, total };
-      })
-      .filter(Boolean) as { label: string; missed: number; total: number }[];
-
-    // Longest absence streak
-    const sorted = [...scheduled].sort((a, b) => a.getTime() - b.getTime());
-    let maxAbsence = 0;
-    let absenceRun = 0;
-    for (const d of sorted) {
-      if (!attendedSet.has(d.toISOString().slice(0, 10))) {
-        absenceRun++;
-        maxAbsence = Math.max(maxAbsence, absenceRun);
-      } else {
-        absenceRun = 0;
-      }
-    }
-
-    // Attendance streaks (up to today)
-    const today = new Date();
-    const scheduledToToday = sorted.filter((d) => d <= today);
-    let longestAttendance = 0;
-    let attendanceRun = 0;
-    for (const d of scheduledToToday) {
-      if (attendedSet.has(d.toISOString().slice(0, 10))) {
-        attendanceRun++;
-        longestAttendance = Math.max(longestAttendance, attendanceRun);
-      } else {
-        attendanceRun = 0;
-      }
-    }
-    let currentAttendance = 0;
-    for (let i = scheduledToToday.length - 1; i >= 0; i--) {
-      if (attendedSet.has(scheduledToToday[i].toISOString().slice(0, 10))) currentAttendance++;
-      else break;
-    }
-
-    return { aggregate, absenceByWeekday, longestAbsenceStreak: maxAbsence, currentAttendanceStreak: currentAttendance, longestAttendanceStreak: longestAttendance };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedUser?.id, attendance, noClasses]);
 
   return (
     <div className="space-y-4">
@@ -332,7 +285,6 @@ const CoachAttendance: React.FC<CoachAttendanceProps> = ({ seluser = null, showC
                   <TabsTrigger value="kontaktinfo">Kontaktinfo</TabsTrigger>
                   <TabsTrigger value="larare">{userType === "Admin" ? "Lärarkontakt" : "Lärare på kursen"}</TabsTrigger>
                   {/* <TabsTrigger value="progression">Progression</TabsTrigger> */}{/* Students temporarily disabled */}
-                  <TabsTrigger value="statistik">Statistik</TabsTrigger>
                 </TabsList>
                 <HelpDialog helpKey={activeTab === "narvaro" && userType === "Coach" ? "attendance.narvaro.coach" : `attendance.${activeTab}`} />
               </div>
@@ -391,6 +343,41 @@ const CoachAttendance: React.FC<CoachAttendanceProps> = ({ seluser = null, showC
                         })}
                       </TableRow>
                     ))}
+                  </TableBody>
+                </Table>
+                </div>
+
+                <div className="mt-6 space-y-1">
+                  <p className="text-sm"><strong>Startdatum:</strong> {selectedUser.startDate ? new Date(selectedUser.startDate).toLocaleDateString("sv-SE") : "Ej angivet"}</p>
+                  <p className="text-sm"><strong>Senaste närvarodag:</strong> {(() => {
+                    const dates = statsAttendance.filter((x) => x.userId === selectedUser.id).flatMap((a) => a.date);
+                    if (dates.length === 0) return "Aldrig närvarat";
+                    const latest = dates.sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0];
+                    return new Date(latest).toLocaleDateString("sv-SE");
+                  })()}</p>
+                </div>
+
+                <h3 className="text-sm font-semibold mt-4 mb-2">Närvaro per månad</h3>
+                <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Månad</TableHead>
+                      <TableHead className="text-center">Antal närvaro dagar</TableHead>
+                      <TableHead className="text-center">Närvaro i procent utifrån schemalagda dagar</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {[0, -1, -2].map((offset) => {
+                      const m = monthStats(offset);
+                      return (
+                        <TableRow key={offset}>
+                          <TableCell className="font-medium">{getMonthName(offset)}</TableCell>
+                          <TableCell className="text-center">{m.attended}</TableCell>
+                          <TableCell className="text-center">{m.pct}%</TableCell>
+                        </TableRow>
+                      );
+                    })}
                   </TableBody>
                 </Table>
                 </div>
@@ -475,58 +462,6 @@ const CoachAttendance: React.FC<CoachAttendanceProps> = ({ seluser = null, showC
                         ))}
                       </TableBody>
                     </Table>
-                    </div>
-                  </>
-                )}
-              </TabsContent>
-              <TabsContent value="statistik">
-                <p className="text-sm"><strong>Startdatum:</strong> {selectedUser?.startDate ? new Date(selectedUser.startDate).toLocaleDateString("sv-SE") : "Ej angivet"}</p>
-                <p className="text-sm"><strong>Senaste närvarodag:</strong> {(() => {
-                  const dates = attendance.filter((x) => x.userId === selectedUser.id).flatMap((a) => a.date);
-                  if (dates.length === 0) return "Aldrig närvarat";
-                  const latest = dates.sort((a, b) => new Date(b).getTime() - new Date(a).getTime())[0];
-                  return new Date(latest).toLocaleDateString("sv-SE");
-                })()}</p>
-
-                <h3 className="text-sm font-semibold mt-4 mb-2">Närvaro per månad</h3>
-                <div className="overflow-x-auto">
-                <Table>
-                  <TableHeader><TableRow><TableHead></TableHead><TableHead>{getMonthName(0)}</TableHead><TableHead>{getMonthName(-1)}</TableHead><TableHead>{getMonthName(-2)}</TableHead></TableRow></TableHeader>
-                  <TableBody>
-                    <TableRow>
-                      <TableCell>Närvaro utifrån schema:</TableCell>
-                      <TableCell>{printScheduledDays(0)}</TableCell>
-                      <TableCell>{printScheduledDays(-1)}</TableCell>
-                      <TableCell>{printScheduledDays(-2)}</TableCell>
-                    </TableRow>
-                  </TableBody>
-                </Table>
-                </div>
-
-                {threeMonthStats && (
-                  <>
-                    <p className="text-sm mt-4"><strong>Totalt senaste 3 månader:</strong> {threeMonthStats.aggregate}</p>
-
-                    <h3 className="text-sm font-semibold mt-4 mb-2">Frånvaro per veckodag</h3>
-                    <div className="overflow-x-auto">
-                    <Table>
-                      <TableHeader><TableRow><TableHead>Veckodag</TableHead><TableHead>Missat</TableHead><TableHead>Schemalagt</TableHead></TableRow></TableHeader>
-                      <TableBody>
-                        {threeMonthStats.absenceByWeekday.map((row) => (
-                          <TableRow key={row.label}>
-                            <TableCell>{row.label}</TableCell>
-                            <TableCell>{row.missed}</TableCell>
-                            <TableCell>{row.total}</TableCell>
-                          </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
-                    </div>
-
-                    <div className="mt-4 space-y-1">
-                      <p className="text-sm"><strong>Längsta frånvarosvit:</strong> {threeMonthStats.longestAbsenceStreak} schemalagda dagar</p>
-                      <p className="text-sm"><strong>Nuvarande närvarosvit:</strong> {threeMonthStats.currentAttendanceStreak} schemalagda dagar</p>
-                      <p className="text-sm"><strong>Längsta närvarosvit:</strong> {threeMonthStats.longestAttendanceStreak} schemalagda dagar</p>
                     </div>
                   </>
                 )}

--- a/src/components/statistik/AttendanceStats.tsx
+++ b/src/components/statistik/AttendanceStats.tsx
@@ -147,7 +147,6 @@ export default function AttendanceStats() {
       <TableCell className="text-center">{fmt(s.median)}</TableCell>
       <TableCell className="text-center">{fmt(s.min)}</TableCell>
       <TableCell className="text-center">{fmt(s.max)}</TableCell>
-      <TableCell className="text-center">{fmt(s.stdDev)}</TableCell>
     </TableRow>
   );
 
@@ -189,7 +188,6 @@ export default function AttendanceStats() {
                     <TableHead className="text-center">Median</TableHead>
                     <TableHead className="text-center">Min</TableHead>
                     <TableHead className="text-center">Max</TableHead>
-                    <TableHead className="text-center">Std.avv</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>{stats.perWeekday.map((w) => renderSummaryRow(w.label, w.summary))}</TableBody>
@@ -208,7 +206,6 @@ export default function AttendanceStats() {
                     <TableHead className="text-center">Median</TableHead>
                     <TableHead className="text-center">Min</TableHead>
                     <TableHead className="text-center">Max</TableHead>
-                    <TableHead className="text-center">Std.avv</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>{stats.perSpar.map((s) => renderSummaryRow(s.label, s.summary))}</TableBody>

--- a/src/components/statistik/ComputerStats.tsx
+++ b/src/components/statistik/ComputerStats.tsx
@@ -36,6 +36,15 @@ export default function ComputerStats() {
   const dedicated = computers.filter((c) => c.ownerStudentId != null).length;
   const shared = total - dedicated;
 
+  // Split the shared computers by booking state so we can see at a glance how many
+  // are free to lend: "delvis bokade" have at least one slot booked, "helt obokade"
+  // have none at all and can be lent out without disturbing anyone.
+  const bookedComputerIds = new Set(assignments.map((a) => a.computerId));
+  const partiallyBooked = computers.filter(
+    (c) => c.ownerStudentId == null && bookedComputerIds.has(c.id)
+  ).length;
+  const fullyUnbooked = shared - partiallyBooked;
+
   if (total === 0) {
     return <Card className="p-8 text-center text-muted-foreground">Inga datorer tillagda ännu.</Card>;
   }
@@ -44,8 +53,9 @@ export default function ComputerStats() {
     <div className="space-y-4">
       <div className="text-sm space-y-0.5">
         <p>Total antal datorer: <strong>{total}</strong></p>
-        <p>Antal tilldelade datorer: <strong>{dedicated}</strong></p>
-        <p>Antal delade datorer: <strong>{shared}</strong></p>
+        <p>Antal utlånade: <strong>{dedicated}</strong></p>
+        <p>Antal delvis bokade: <strong>{partiallyBooked}</strong></p>
+        <p>Antal helt obokade: <strong>{fullyUnbooked}</strong></p>
       </div>
       <p className="text-sm text-muted-foreground">
         Tilldelade och lediga delade datorer per pass.

--- a/src/pages/Datorer.tsx
+++ b/src/pages/Datorer.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import HelpDialog from "@/components/HelpDialog";
@@ -191,6 +192,9 @@ export default function Datorer() {
     [users]
   );
 
+  const sharedComputers = useMemo(() => computers.filter((c) => c.ownerStudentId == null), [computers]);
+  const ownedComputers = useMemo(() => computers.filter((c) => c.ownerStudentId != null), [computers]);
+
   const handleAdd = () => {
     const num = parseInt(newNumber, 10);
     if (!num || num < 1) {
@@ -245,11 +249,36 @@ export default function Datorer() {
       {computers.length === 0 ? (
         <Card className="p-8 text-center text-muted-foreground">Inga datorer tillagda ännu.</Card>
       ) : (
-        <div className="space-y-4">
-          {computers.map((c) => (
-            <ComputerCard key={c.id} computer={c} computers={computers} assignments={assignments} students={students} />
-          ))}
-        </div>
+        <Tabs defaultValue="shared">
+          <TabsList>
+            <TabsTrigger value="shared">Delade datorer ({sharedComputers.length})</TabsTrigger>
+            <TabsTrigger value="owned">Egen dator ({ownedComputers.length})</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="shared" className="mt-4">
+            {sharedComputers.length === 0 ? (
+              <Card className="p-8 text-center text-muted-foreground">Inga delade datorer.</Card>
+            ) : (
+              <div className="space-y-4">
+                {sharedComputers.map((c) => (
+                  <ComputerCard key={c.id} computer={c} computers={computers} assignments={assignments} students={students} />
+                ))}
+              </div>
+            )}
+          </TabsContent>
+
+          <TabsContent value="owned" className="mt-4">
+            {ownedComputers.length === 0 ? (
+              <Card className="p-8 text-center text-muted-foreground">Inga egna datorer.</Card>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                {ownedComputers.map((c) => (
+                  <ComputerCard key={c.id} computer={c} computers={computers} assignments={assignments} students={students} />
+                ))}
+              </div>
+            )}
+          </TabsContent>
+        </Tabs>
       )}
     </div>
   );

--- a/src/pages/Klassrum.tsx
+++ b/src/pages/Klassrum.tsx
@@ -28,11 +28,13 @@ export const SPAR1_LAYOUT: { row: number; col: number }[] = [
   { row: 4, col: 1 }, { row: 4, col: 2 }, { row: 4, col: 3 }, { row: 4, col: 4 },
 ];
 
-// Spår 2 layout: row 1 has 6 tables in pairs, row 2 has 2 tables at edges
-// Using col 1-6 for the 6 positions in row 1
+// Spår 2 layout: row 1 has 6 tables in pairs, row 2 (middle) has 1 table at the right wall,
+// row 3 has tables at both walls plus one in the middle.
+// Using col 1-6 for the 6 positions in row 1.
 export const SPAR2_LAYOUT: { row: number; col: number }[] = [
   { row: 1, col: 1 }, { row: 1, col: 2 }, { row: 1, col: 3 }, { row: 1, col: 4 }, { row: 1, col: 5 }, { row: 1, col: 6 },
-  { row: 2, col: 1 }, { row: 2, col: 6 },
+  { row: 2, col: 6 },
+  { row: 3, col: 1 }, { row: 3, col: 3 }, { row: 3, col: 6 },
 ];
 
 function hasTable(row: number, col: number, layout: { row: number; col: number }[]): boolean {
@@ -264,9 +266,10 @@ function ClassroomGrid({ classroomId, students: allStudents, dayOfWeek }: { clas
     );
   }
 
-  // Spår 2: wider room, 2 rows
+  // Spår 2: wider room, 3 rows
   // Row 1: 3 pairs of facing tables with gaps between pairs (col 1-2, 3-4, 5-6)
-  // Row 2: table at col 1 and col 6 only
+  // Row 2 (middle): table at the right wall (col 6) only
+  // Row 3: tables at both walls (col 1, col 6) plus one in the middle (col 3)
   return (
     <div className="flex gap-8">
       <div className="flex-1">
@@ -284,8 +287,8 @@ function ClassroomGrid({ classroomId, students: allStudents, dayOfWeek }: { clas
             <div key={`1-${col}`}><TableCell row={1} col={col} {...props} /></div>,
           ])}
 
-          {/* Row 2: col 1 and col 6 only */}
-          <div key="2-1"><TableCell row={2} col={1} {...props} /></div>
+          {/* Row 2 (middle): right wall (col 6) only */}
+          <div key="2-1" />
           <div key="2-2" />
           <div key="2-gap1" />
           <div key="2-3" />
@@ -293,6 +296,16 @@ function ClassroomGrid({ classroomId, students: allStudents, dayOfWeek }: { clas
           <div key="2-gap2" />
           <div key="2-5" />
           <div key="2-6"><TableCell row={2} col={6} {...props} /></div>
+
+          {/* Row 3: left wall (col 1), middle (col 3), right wall (col 6) */}
+          <div key="3-1"><TableCell row={3} col={1} {...props} /></div>
+          <div key="3-2" />
+          <div key="3-gap1" />
+          <div key="3-3"><TableCell row={3} col={3} {...props} /></div>
+          <div key="3-4" />
+          <div key="3-gap2" />
+          <div key="3-5" />
+          <div key="3-6"><TableCell row={3} col={6} {...props} /></div>
 
           {/* Footer */}
           <div className="col-span-8 text-xs text-muted-foreground text-center mt-1">FM / EM per bord</div>


### PR DESCRIPTION
## Summary
- **Klassrum (Spår 2):** third table row — a right-wall table in the new middle row and a middle table in the bottom row.
- **Datorer:** split into **Delade datorer** / **Egen dator** tabs; owned computers render two cards per row.
- **Statistik → Datorer:** relabelled to *Antal utlånade* / *Antal delvis bokade*, plus a new *Antal helt obokade* row to spot lendable machines.
- **Statistik → Närvaro:** removed the standard-deviation column.
- **Deltagare:** retired the Statistik tab; moved Startdatum, Senaste närvarodag and Närvaro per månad under the Närvaro tab. The monthly table now lists months as rows with *Antal närvarodagar* and *Närvaro i procent* columns.
- **Fix:** Senaste närvarodag (and the monthly table) now query the participant's full enrolment window instead of the 2-week grid window, so attendance older than ~2 weeks is no longer missed.

## Verification
- \`tsc --noEmit\` clean.
- Verified each change in the browser (Playwright); the attendance fix confirmed against real data (Senaste närvarodag resolves to 2026-03-04 instead of "Aldrig närvarat").

🤖 Generated with [Claude Code](https://claude.com/claude-code)